### PR TITLE
使用数字0退出脚本，常用功能了，变来变去不太方便

### DIFF
--- a/PalServerInstall.sh
+++ b/PalServerInstall.sh
@@ -696,7 +696,7 @@ case "$num" in
     ;;
     *)
     clear
-    echo -e "${Green}请输入正确数字 [1-17]${Font}"
+    echo -e "${Green}请输入正确数字 [0-16]${Font}"
     sleep 2s
     main
     ;;

--- a/PalServerInstall.sh
+++ b/PalServerInstall.sh
@@ -621,6 +621,7 @@ echo -e "${Green}Linux VPS一键安装管理幻兽帕鲁服务端脚本${Font}"
 echo -e "${Green}脚本版本${currentScriptVersion}${Font}"
 echo -e "${Green}教程地址：https://www.xuehaiwu.com/palworld-server/${Font}"
 echo -e "${Green}服务器购买：https://curl.qcloud.com/WJYPYPoQ ${Font}"
+echo -e "${Green}0、退出脚本${Font}"
 echo -e "${Green}1、安装幻兽帕鲁服务端${Font}"
 echo -e "${Green}2、启动幻兽帕鲁服务端${Font}"
 echo -e "${Green}3、停止幻兽帕鲁服务端${Font}"
@@ -637,11 +638,14 @@ echo -e "${Green}13、导入幻兽帕鲁存档及配置${Font}"
 echo -e "${Green}14、导出幻兽帕鲁存档及配置${Font}"
 echo -e "${Green}15、增加定时备份幻兽帕鲁存档及配置${Font}"
 echo -e "${Green}16、增加定时容器内存占用检测，超出存档并重启${Font}"
-echo -e "${Green}17、退出脚本${Font}"
 echo -e "———————————————————————————————————————"
-read -p "请输入数字 [1-17]:" num
+read -p "请输入数字 [0-16]:" num
 check_numeric_input $num
 case "$num" in
+    0)
+    echo -e "${Green}退出脚本...${Font}"
+    exit 0
+    ;;
     1)
     install_pal_server
     ;;
@@ -689,10 +693,6 @@ case "$num" in
     ;;
     16)
     add_rcon_restart
-    ;;
-    17)
-    echo -e "${Green}退出脚本...${Font}"
-    exit 0
     ;;
     *)
     clear

--- a/backup.sh
+++ b/backup.sh
@@ -14,7 +14,7 @@ check_docker_container() {
 }
 export_pal_server() {
     if check_docker_container; then
-        local timestamp=$(date "+%Y-%m-%d_%H:%M:%S")
+        local timestamp=$(date "+%Y-%m-%d_%H-%M-%S")
         local backup_dir="/data/backup/backup_$timestamp/"
         echo -e "${Green}此操作会导出容器内 /home/steam/Steam/steamapps/common/PalServer/Pal/Saved 文件夹下所有的文件${Font}"
         echo -e "${Green}导出的幻兽帕鲁存档及配置将会存放在 $backup_dir 目录下！${Font}"


### PR DESCRIPTION
固定一个数字退出应该比较好？


发现备份文件，因带冒号，在解压时可能导致报错（Ubuntu 22.04.3 LTS）

![image](https://github.com/2lifetop/Pal-Server-Install/assets/676412/9891afeb-99cb-489f-8e68-d65009dd1936)
![image](https://github.com/2lifetop/Pal-Server-Install/assets/676412/7692c886-33b6-401b-af1e-b0bcbcab3a62)
![image](https://github.com/2lifetop/Pal-Server-Install/assets/676412/1159e686-6469-4ba9-8982-1d80ca25dadb)


